### PR TITLE
Add K8s token reload on 401 error for K8s storage client

### DIFF
--- a/charts/platform-buckets/.gitignore
+++ b/charts/platform-buckets/.gitignore
@@ -1,0 +1,2 @@
+charts/
+Chart.lock

--- a/charts/platform-buckets/templates/_helpers.tpl
+++ b/charts/platform-buckets/templates/_helpers.tpl
@@ -25,3 +25,7 @@ chart: {{ include "platformBuckets.chart" . }}
 heritage: {{ .Release.Service | quote }}
 release: {{ .Release.Name | quote }}
 {{- end -}}
+
+{{- define "platformBuckets.kubeAuthMountRoot" -}}
+{{- printf "/var/run/secrets/kubernetes.io/serviceaccount" -}}
+{{- end -}}

--- a/charts/platform-buckets/templates/deployment.yaml
+++ b/charts/platform-buckets/templates/deployment.yaml
@@ -63,9 +63,9 @@ spec:
         - name: NP_BUCKETS_API_K8S_AUTH_TYPE
           value: token
         - name: NP_BUCKETS_API_K8S_CA_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          value: {{ include "platformBuckets.kubeAuthMountRoot" . }}/ca.crt
         - name: NP_BUCKETS_API_K8S_TOKEN_PATH
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+          value: {{ include "platformBuckets.kubeAuthMountRoot" . }}/token
         - name: NP_BUCKETS_API_K8S_NS
           value: {{ .Values.bucketNamespace }}
         - name: NP_CLUSTER_NAME
@@ -171,6 +171,10 @@ spec:
         - name: NP_BUCKETS_API_DISABLE_CREATION
           value: "true"
         {{- end }}
+        volumeMounts:
+        - mountPath: {{ include "platformBuckets.kubeAuthMountRoot" . }}
+          name: kube-api-token
+          readOnly: true
 
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
@@ -178,3 +182,15 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      volumes:
+      - name: kube-api-data
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3600
+              path: token
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt

--- a/platform_buckets_api/api.py
+++ b/platform_buckets_api/api.py
@@ -858,7 +858,7 @@ async def create_kube_client(
         auth_cert_path=config.auth_cert_path,
         auth_cert_key_path=config.auth_cert_key_path,
         token=config.token,
-        token_path=None,  # TODO (A Yushkovskiy) add support for token_path or drop
+        token_path=config.token_path,
         conn_timeout_s=config.client_conn_timeout_s,
         read_timeout_s=config.client_read_timeout_s,
         watch_timeout_s=config.client_watch_timeout_s,

--- a/platform_buckets_api/config.py
+++ b/platform_buckets_api/config.py
@@ -120,6 +120,7 @@ class KubeConfig:
     auth_cert_path: Optional[str] = None
     auth_cert_key_path: Optional[str] = None
     token: Optional[str] = field(repr=False, default=None)
+    token_path: Optional[str] = None
     namespace: str = "default"
     client_conn_timeout_s: int = 300
     client_read_timeout_s: int = 300

--- a/platform_buckets_api/config_factory.py
+++ b/platform_buckets_api/config_factory.py
@@ -184,6 +184,7 @@ class EnvironConfigFactory:
                 "NP_BUCKETS_API_K8S_AUTH_CERT_KEY_PATH"
             ),
             token=token,
+            token_path=token_path,
             namespace=self._environ.get("NP_BUCKETS_API_K8S_NS", KubeConfig.namespace),
             client_conn_timeout_s=int(
                 self._environ.get("NP_BUCKETS_API_K8S_CLIENT_CONN_TIMEOUT")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -114,6 +114,7 @@ def test_create_custom(cert_authority_path: str, token_path: str) -> None:
             cert_authority_data_pem=CA_DATA_PEM,
             auth_type=KubeClientAuthType.TOKEN,
             token=TOKEN,
+            token_path=token_path,
             auth_cert_path="/cert_path",
             auth_cert_key_path="/cert_key_path",
             namespace="other-namespace",


### PR DESCRIPTION
In the case of 401(Unauthorized) response from Kubernetes API, we re-read the token from file system and retry the request (once only).
The token is mounted as projectedVolume into the pod and auto-updated by kubelet.

Unfortunately, I didn't come up with some more-or-less simple test implementation so I left this logic uncovered. If someone has an idea - I would be glad to implement it. 