### PR TITLE
Switch platform services to seaweedfs

### DIFF
--- a/charts/platform-buckets/templates/deployment.yaml
+++ b/charts/platform-buckets/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
         - name: NP_MINIO_SECRET_ACCESS_KEY
           {{- toYaml .Values.bucketProvider.minio.secretAccessKey | nindent 10 }}
         - name: NP_MINIO_REGION_NAME
-          value: {{ .Values.bucketProvider.minio.regionName | default "minio" }}
+          value: {{ .Values.bucketProvider.minio.regionName | default "us-east-1" }}
         {{- end }}
         # Azure provider
         {{- if eq .Values.bucketProvider.type "azure" }}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -129,17 +129,17 @@ def test_create_minio() -> None:
         "NP_BUCKET_PROVIDER_TYPE": "minio",
         "NP_MINIO_ACCESS_KEY_ID": "key-id",
         "NP_MINIO_SECRET_ACCESS_KEY": "key-secret",
-        "NP_MINIO_REGION_NAME": "region",
-        "NP_MINIO_ENDPOINT_URL": "https://play.min.io",
-        "NP_MINIO_ENDPOINT_PUBLIC_URL": "https://public.play.min.io",
+        "NP_MINIO_REGION_NAME": "us-east-1",
+        "NP_MINIO_ENDPOINT_URL": "http://seaweedfs-s3.platform.svc.cluster.local:9000",
+        "NP_MINIO_ENDPOINT_PUBLIC_URL": "http://seaweedfs-s3.platform.svc.cluster.local:9000",
     }
     config = EnvironConfigFactory(environ).create_bucket_provider()
     assert config == MinioProviderConfig(
         access_key_id="key-id",
         secret_access_key="key-secret",
-        region_name="region",
-        endpoint_url=URL("https://play.min.io"),
-        endpoint_public_url=URL("https://public.play.min.io"),
+        region_name="us-east-1",
+        endpoint_url=URL("http://seaweedfs-s3.platform.svc.cluster.local:9000"),
+        endpoint_public_url=URL("http://seaweedfs-s3.platform.svc.cluster.local:9000"),
     )
 
 


### PR DESCRIPTION
This pull request updates the configuration for S3-compatible storage used in platform monitoring, switching from MinIO to SeaweedFS S3, and updates all relevant credentials, endpoints, and regions across integration tests, unit tests, and Kubernetes manifests. These changes ensure consistency and correct connectivity for log storage in the new environment.

S3 Storage Provider Migration and Configuration Updates

_Switchover from MinIO to SeaweedFS S3:_

- Changed all S3 endpoint URLs from http://minio:9000 to http://seaweedfs-s3.platform.svc.cluster.local:9000 in integration test fixtures, Kubernetes manifests, and unit tests.