### PR TITLE
IT-126: bump apolo-kube-client to 25.12.2 (ingress-gateway netpol fix)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -321,14 +321,14 @@ pytest = ["pytest (>=8.4.1)", "pytest-aiohttp (>=1.1.0)", "pytest-asyncio (>=1.0
 
 [[package]]
 name = "apolo-kube-client"
-version = "25.12.1"
+version = "25.12.2"
 description = "Apolo internal client for kubernetes API"
 optional = false
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 files = [
-    {file = "apolo_kube_client-25.12.1-py3-none-any.whl", hash = "sha256:7fde674055bd9695919413cf834a81f632f4850675d840ba59ad67dbb2eb6bca"},
-    {file = "apolo_kube_client-25.12.1.tar.gz", hash = "sha256:55e798eeacc0f80dd70c1928b625a8678f0b3faf4df47332120f61f6e2cd0ef0"},
+    {file = "apolo_kube_client-25.12.2-py3-none-any.whl", hash = "sha256:a8a852b2f04051851c1e83cbe275213b26e784401a3a59c113bfe8384e4fe484"},
+    {file = "apolo_kube_client-25.12.2.tar.gz", hash = "sha256:4c11bbc4d87e26d7972c74a3e9cc3ecfbd99d3dd4cfd8eec4e7855cc9de6a5f5"},
 ]
 
 [package.dependencies]
@@ -3573,4 +3573,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "4f385a1f5c68da52d712cd3fb492432c115a17beea4e34e6490fd0bdd21f63a9"
+content-hash = "ea54b7f7af782855b161500d27fe49adeb4a241181fd2c731e161afa137f46ee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ azure-storage-blob = "12.30.0"
 google-cloud-storage = "3.13.0"
 google-cloud-iam = "2.24.0"
 google-api-python-client = "2.198.0"
-apolo-kube-client = "25.12.1"
+apolo-kube-client = "25.12.2"
 apolo-events-client = "26.7.1"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Bumps apolo-kube-client 25.12.1 → 25.12.2 (exact pin, so pyproject + lock).

25.12.2 fixes the per-project egress NetworkPolicy: the ingress-gateway rule’s `namespaceSelector` was an empty `V1LabelSelector()` dropped on serialization, leaving it podSelector-only (same-namespace) so project pods could not reach traefik in `platform`. platform-buckets-api creates/touches project namespaces + this netpol via `KubeClientSelector.get_client(ensure_namespace=True)`, so shipping this propagates the fix on next access.

Paired with cloud-infra #491 (traefik ingress-gateway label). Ref: IT-126.